### PR TITLE
docs: added deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,2 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/9tct1gexrr4dfoki?svg=true)](https://ci.appveyor.com/project/edewit/fh-csharp-window-10-blank-app)
-
-fh-csharp-window-10-blank-app
-=============================
-
-Blank app with FeedHenry SDK included for Windows 10 Universal Apps
+## Deprecation Notice
+This repository has been deprecated and is **not being maintained** as of December 2017. **It should not be used**. If you have any questions, please get in touch with the collaborators.


### PR DESCRIPTION
## What is this change?

Documentation change to note that this template repo is deprecated and no longer maintained

## Related JIRAs/ issues

Change relates to [RHMAP-18540](https://issues.jboss.org/browse/RHMAP-18540) (deprecation of Windows support)